### PR TITLE
Add PostgreSQL and Redis TLS connection support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,22 @@ miarecweb_db_pool_recycle: 3600
 miarecweb_db_pool_use_lifo: true
 
 # -----------------------------
+# PostgreSQL TLS settings
+# -----------------------------
+miarecweb_db_tls: false
+miarecweb_db_tls_sslmode: verify-ca
+# TLS mode options:
+#   disable - Plain TCP, TLS not requested
+#   allow - Try plain TCP first, then TLS if rejected
+#   prefer - Try TLS first, fall back to plain TCP (default if sslmode not set)
+#   require - TLS required, no server cert validation
+#   verify-ca - TLS required, validate server cert against CA
+#   verify-full - TLS required, validate server cert and hostname
+miarecweb_db_tls_ca_file: ""       # CA certificate to validate server
+miarecweb_db_tls_cert_file: ""     # Client certificate for mTLS
+miarecweb_db_tls_key_file: ""      # Client private key for mTLS
+
+# -----------------------------
 # Redis settings
 # -----------------------------
 miarecweb_redis_host: 127.0.0.1
@@ -56,6 +72,16 @@ miarecweb_redis_socket_connect_timeout: 60
 miarecweb_redis_socket_keepalive: true
 miarecweb_redis_health_check_interval: 300
 miarecweb_redis_pool_recycle: 3600
+
+# -----------------------------
+# Redis TLS settings
+# -----------------------------
+miarecweb_redis_tls: false
+miarecweb_redis_tls_ca_file: ""           # CA certificate to validate server
+miarecweb_redis_tls_cert_file: ""         # Client certificate for mTLS
+miarecweb_redis_tls_key_file: ""          # Client private key for mTLS
+miarecweb_redis_tls_cert_reqs: required   # required, optional, or none
+miarecweb_redis_tls_check_hostname: false # Verify server hostname
 
 # -----------------------------
 # mod_wsgi settings

--- a/docs/prs/pr_012_postgres_redis_tls.md
+++ b/docs/prs/pr_012_postgres_redis_tls.md
@@ -1,0 +1,85 @@
+## Summary
+
+Add TLS/SSL connection support for PostgreSQL and Redis, enabling encrypted and optionally mutually-authenticated (mTLS) connections to database services.
+
+---
+
+## Purpose
+
+This change enables secure database connections in environments that require TLS encryption for compliance or security requirements. It supports:
+- Server certificate validation (verify-ca, verify-full)
+- Client certificate authentication (mTLS)
+- Flexible SSL mode configuration for PostgreSQL
+- Redis TLS with configurable certificate requirements
+
+---
+
+## Testing
+
+* [x] Added/updated tests
+* [x] Ran `uv run ansible-lint` (1 minor warning in test infrastructure)
+* Notes:
+  - New `molecule/tls` scenario tests full mTLS configuration
+  - Tests verify TLS certificates, production.ini configuration, health endpoints, and alembic connectivity
+  - Tested on Ubuntu 24.04 and Rocky Linux 9
+
+---
+
+## Related Issues
+
+N/A
+
+---
+
+## Changes
+
+### New Variables (defaults/main.yml)
+
+**PostgreSQL TLS:**
+- `miarecweb_db_tls` - Enable TLS (default: false)
+- `miarecweb_db_tls_sslmode` - SSL mode: disable, allow, prefer, require, verify-ca, verify-full (default: verify-ca)
+- `miarecweb_db_tls_ca_file` - CA certificate path
+- `miarecweb_db_tls_cert_file` - Client certificate path (for mTLS)
+- `miarecweb_db_tls_key_file` - Client private key path (for mTLS)
+
+**Redis TLS:**
+- `miarecweb_redis_tls` - Enable TLS (default: false)
+- `miarecweb_redis_tls_ca_file` - CA certificate path
+- `miarecweb_redis_tls_cert_file` - Client certificate path (for mTLS)
+- `miarecweb_redis_tls_key_file` - Client private key path (for mTLS)
+- `miarecweb_redis_tls_cert_reqs` - Certificate requirement: required, optional, none (default: required)
+- `miarecweb_redis_tls_check_hostname` - Verify server hostname (default: false)
+
+### Role Changes
+
+- **Preflight validation** - Validates TLS certificate files exist before deployment
+- **Security enforcement** - Requires non-root celery user when using client certificates
+- **Permission management** - Sets appropriate group ownership on TLS private keys
+- **Configuration generation** - Writes DATABASE_SSL_PARAMS and REDIS_SSL_PARAMS to production.ini
+- **Database migrations** - Passes TLS environment variables to alembic commands
+
+### Test Infrastructure
+
+- New `molecule/tls` scenario with full mTLS testing
+- CA and client certificate generation
+- PostgreSQL and Redis TLS server configuration
+- Comprehensive test coverage for TLS connectivity
+
+---
+
+## Notes for Reviewers
+
+1. **Breaking change consideration**: When TLS with client certificates is enabled, the role now requires `miarecweb_celery_user` to be set to a non-root user and `miarec_bin_group` to be configured. This ensures the celery worker can read the private key files.
+
+2. **Certificate management**: This role provisions TLS parameters but does NOT manage certificate deployment. Certificates must be pre-deployed to the target system before running this role.
+
+3. **Redis schema change**: When `miarecweb_redis_tls` is enabled, the Redis connection URL scheme changes from `redis://` to `rediss://`.
+
+4. **ansible-lint warning**: One minor `risky-shell-pipe` warning in `molecule/tls/tasks/redis_tls.yml:120` - this is in test infrastructure only, not the main role.
+
+---
+
+## Docs
+
+* [x] N/A (internal role, no external documentation required)
+* [ ] Updated relevant documentation

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,14 +17,6 @@
       changed_when: false
       when: ansible_facts['os_family'] == "Debian"
 
-    # required for miarecweb.yml - Install dependencies (requirements.txt)
-    # I want to re test this, I dont ubderstand why we need system python pip
-    - name: Install python-pip | CentOS
-      package:
-        name: python-pip
-        state: present
-      when: ansible_facts['distribution'] == "CentOS"
-
   roles:
     - role: ansible-role-miarecweb
       tags:

--- a/molecule/default/tasks/apache.yml
+++ b/molecule/default/tasks/apache.yml
@@ -21,16 +21,6 @@
     enabled: true
   when: ansible_facts['os_family'] == "Debian"
 
-# CentOS repository and UBI repository have mismatched versions of httpd
-# this causes and issue with httpd-devel is installed from CentOS repository
-# disabling UBI repository to force install from CentOS repository
-- name: Disable ubi-7 repository | RHEL 7
-  command: yum-config-manager --disable ubi-7
-  changed_when: false
-  when:
-    - ansible_facts['os_family'] == "RedHat"
-    - ansible_facts['distribution_major_version'] == "7"
-
 # Install apache on CentOS7, Rocky8-9, RHEL8-9
 - name: Apache | Install Apache | RedHat
   yum:

--- a/molecule/default/tasks/redis.yml
+++ b/molecule/default/tasks/redis.yml
@@ -1,25 +1,6 @@
 ---
 # Install Redis from system packages (based on ansible-role-redis)
 
-# Install EPEL for CentOS (required for redis package)
-- name: Redis | Install EPEL | CentOS
-  package:
-    name: epel-release
-    state: present
-  when: ansible_facts['distribution'] == "CentOS"
-
-# Install EPEL for RedHat 7
-- name: Redis | Install EPEL | RedHat 7
-  yum_repository:
-    name: epel
-    description: EPEL
-    baseurl: "https://dl.fedoraproject.org/pub/archive/epel/7/x86_64/"
-    gpgkey: "http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_facts['distribution_major_version'] }}"
-    enabled: true
-  when:
-    - ansible_facts['distribution'] == "RedHat"
-    - ansible_facts['distribution_major_version'] == "7"
-
 # Install Redis package
 - name: Redis | Install Redis package
   package:

--- a/molecule/tls/converge.yml
+++ b/molecule/tls/converge.yml
@@ -1,0 +1,40 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  pre_tasks:
+
+    - set_fact:
+        miarecweb_version: "{{ lookup('env', 'MIARECWEB_VERSION') }}"
+        miarecweb_secret: "{{ lookup('env', 'MIARECWEB_SECRET') }}"
+        python_version: "{{ lookup('env', 'PYTHON_VERSION') }}"
+
+    - name: Update apt cache | Debian
+      apt:
+        update_cache: true
+        cache_valid_time: 600
+      changed_when: false
+      when: ansible_facts['os_family'] == "Debian"
+
+  roles:
+    - role: ansible-role-miarecweb
+      vars:
+        # MiaRec group configuration (required for TLS certificate access)
+        miarec_bin_group: miarec
+        miarecweb_celery_user: celery
+        # PostgreSQL TLS configuration
+        miarecweb_db_tls: true
+        miarecweb_db_tls_sslmode: verify-ca
+        miarecweb_db_tls_ca_file: /etc/miarecweb/tls/ca.crt
+        miarecweb_db_tls_cert_file: /etc/miarecweb/tls/client.crt
+        miarecweb_db_tls_key_file: /etc/miarecweb/tls/client.key
+        # Redis TLS configuration
+        miarecweb_redis_tls: true
+        miarecweb_redis_tls_ca_file: /etc/miarecweb/tls/ca.crt
+        miarecweb_redis_tls_cert_file: /etc/miarecweb/tls/client.crt
+        miarecweb_redis_tls_key_file: /etc/miarecweb/tls/client.key
+        miarecweb_redis_tls_cert_reqs: required
+        miarecweb_redis_tls_check_hostname: false
+      tags:
+        - miarecweb

--- a/molecule/tls/molecule.yml
+++ b/molecule/tls/molecule.yml
@@ -2,11 +2,11 @@
 dependency:
   name: galaxy
   options:
-    requirements-file: collections.yml
+    requirements-file: ../default/collections.yml
 driver:
   name: docker
 platforms:
-  - name: miarecweb-${MOLECULE_DISTRO:-ubuntu2404}
+  - name: miarecweb-tls-${MOLECULE_DISTRO:-ubuntu2404}
     image: ghcr.io/miarec/${MOLECULE_DISTRO:-ubuntu2404}-systemd:latest
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
@@ -31,3 +31,13 @@ verifier:
   options:
     s: true
     verbose: true
+
+scenario:
+  name: tls
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy

--- a/molecule/tls/prepare.yml
+++ b/molecule/tls/prepare.yml
@@ -1,0 +1,29 @@
+---
+- name: Prepare TLS Environment
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Set python_version from environment
+      set_fact:
+        python_version: "{{ lookup('env', 'PYTHON_VERSION') }}"
+
+    - name: Create miarec group
+      group:
+        name: miarec
+        state: present
+
+    - name: Include Python installation tasks
+      include_tasks: tasks/python.yml
+
+    - name: Include TLS certificate generation tasks
+      include_tasks: tasks/certificates.yml
+
+    - name: Include PostgreSQL TLS setup tasks
+      include_tasks: tasks/postgresql_tls.yml
+
+    - name: Include Redis TLS setup tasks
+      include_tasks: tasks/redis_tls.yml
+
+    - name: Include Apache installation tasks
+      include_tasks: tasks/apache.yml

--- a/molecule/tls/tasks/apache.yml
+++ b/molecule/tls/tasks/apache.yml
@@ -1,0 +1,48 @@
+---
+# Install and configure Apache
+- name: Apache | Install Apache package | Debian
+  apt:
+    name: "{{ item }}"
+    state: present
+    update_cache: true
+  with_items:
+    - apache2
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: Apache | Enable a2enmod rewrite module | Debian
+  command: a2enmod rewrite
+  changed_when: false
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: Apache | Restart Apache service | Debian
+  service:
+    name: apache2
+    state: restarted
+    enabled: true
+  when: ansible_facts['os_family'] == "Debian"
+
+# Install apache on CentOS7, Rocky8-9, RHEL8-9
+- name: Apache | Install Apache | RedHat
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - httpd
+    - httpd-devel
+    - mod_ssl
+  when: ansible_facts['os_family'] == "RedHat"
+
+# Configure Apache
+- name: Apache | Ensure httpd certs are installed | RHEL 8+
+  command: /usr/libexec/httpd-ssl-gencerts
+  changed_when: false
+  when:
+    - ansible_facts['os_family'] == "RedHat"
+    - ansible_facts['distribution_major_version'] | int >= 8
+
+- name: Apache | Restart and Enable Apache service | RedHat
+  service:
+    name: httpd
+    state: started
+    enabled: true
+  when: ansible_facts['os_family'] == "RedHat"

--- a/molecule/tls/tasks/certificates.yml
+++ b/molecule/tls/tasks/certificates.yml
@@ -1,0 +1,105 @@
+---
+# Generate TLS certificates for PostgreSQL and Redis testing
+# - CA and client certificates in /etc/miarecweb/tls/
+# - Server certificates are generated in postgresql_tls.yml and redis_tls.yml
+#   after the respective services are installed (so postgres/redis users exist)
+
+- name: Install OpenSSL
+  package:
+    name: openssl
+    state: present
+
+# ============ Create Directories ============
+- name: Create miarecweb TLS directory
+  file:
+    path: /etc/miarecweb/tls
+    state: directory
+    owner: root
+    group: miarec
+    mode: "0750"
+
+# ============ Generate CA (shared) ============
+- name: Generate CA private key
+  command: openssl genrsa -out /etc/miarecweb/tls/ca.key 4096
+  args:
+    creates: /etc/miarecweb/tls/ca.key
+
+- name: Set CA key permissions
+  file:
+    path: /etc/miarecweb/tls/ca.key
+    mode: "0600"
+
+- name: Generate CA certificate
+  command: >
+    openssl req -x509 -new -nodes
+    -key /etc/miarecweb/tls/ca.key
+    -sha256 -days 365
+    -out /etc/miarecweb/tls/ca.crt
+    -subj "/CN=Test-CA"
+  args:
+    creates: /etc/miarecweb/tls/ca.crt
+
+- name: Set CA certificate permissions
+  file:
+    path: /etc/miarecweb/tls/ca.crt
+    mode: "0644"
+
+# ============ Generate Client Certificate ============
+- name: Generate client private key
+  command: openssl genrsa -out /etc/miarecweb/tls/client.key 2048
+  args:
+    creates: /etc/miarecweb/tls/client.key
+
+- name: Create client certificate config
+  copy:
+    content: |
+      [req]
+      distinguished_name = req_distinguished_name
+      req_extensions = v3_req
+      prompt = no
+
+      [req_distinguished_name]
+      CN = miarec
+
+      [v3_req]
+      keyUsage = digitalSignature
+      extendedKeyUsage = clientAuth
+    dest: /etc/miarecweb/tls/client.cnf
+    mode: "0644"
+
+- name: Generate client CSR
+  command: >
+    openssl req -new
+    -key /etc/miarecweb/tls/client.key
+    -out /etc/miarecweb/tls/client.csr
+    -config /etc/miarecweb/tls/client.cnf
+  args:
+    creates: /etc/miarecweb/tls/client.csr
+
+- name: Sign client certificate with CA
+  command: >
+    openssl x509 -req
+    -in /etc/miarecweb/tls/client.csr
+    -CA /etc/miarecweb/tls/ca.crt
+    -CAkey /etc/miarecweb/tls/ca.key
+    -CAcreateserial
+    -out /etc/miarecweb/tls/client.crt
+    -days 365 -sha256
+    -extensions v3_req
+    -extfile /etc/miarecweb/tls/client.cnf
+  args:
+    creates: /etc/miarecweb/tls/client.crt
+
+- name: Set client key permissions
+  file:
+    path: /etc/miarecweb/tls/client.key
+    owner: root
+    group: miarec
+    mode: "0640"
+
+- name: Set client certificate permissions
+  file:
+    path: /etc/miarecweb/tls/client.crt
+    owner: root
+    group: miarec
+    mode: "0644"

--- a/molecule/tls/tasks/postgresql_tls.yml
+++ b/molecule/tls/tasks/postgresql_tls.yml
@@ -1,0 +1,282 @@
+---
+# Install and Configure PostgreSQL with TLS from system packages
+# Server certificates are generated here after postgres user exists
+
+# ============ Debian ============
+- name: PostgreSQL | Update apt cache | Debian
+  apt:
+    update_cache: true
+    cache_valid_time: 600
+  changed_when: false
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: PostgreSQL | Install PostgreSQL packages | Debian
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - postgresql
+    - postgresql-contrib
+  when: ansible_facts['os_family'] == "Debian"
+
+# Discover PostgreSQL paths using pg_lsclusters
+- name: PostgreSQL | Get cluster info | Debian
+  command: pg_lsclusters -h
+  register: _pg_clusters
+  changed_when: false
+  when: ansible_facts['os_family'] == "Debian"
+
+# pg_lsclusters output: "version cluster port status owner data_directory log_file"
+# Example: "16 main 5432 online postgres /var/lib/postgresql/16/main /var/log/..."
+- name: PostgreSQL | Set PostgreSQL paths | Debian
+  set_fact:
+    _pg_version: "{{ _pg_clusters.stdout_lines[0].split()[0] }}"
+    _pg_cluster: "{{ _pg_clusters.stdout_lines[0].split()[1] }}"
+    _pg_data_dir: "{{ _pg_clusters.stdout_lines[0].split()[5] }}"
+    _pg_conf_dir: "/etc/postgresql/{{ _pg_clusters.stdout_lines[0].split()[0] }}/{{ _pg_clusters.stdout_lines[0].split()[1] }}"
+  when: ansible_facts['os_family'] == "Debian"
+
+# ============ RedHat ============
+- name: PostgreSQL | Install PostgreSQL packages | RedHat
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - postgresql-server
+    - postgresql-contrib
+  register: _postgresql_install
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: PostgreSQL | Initialize the database | RedHat
+  command: postgresql-setup --initdb
+  when:
+    - ansible_facts['os_family'] == "RedHat"
+    - _postgresql_install.changed
+  changed_when: true
+
+# System PostgreSQL packages always use /var/lib/pgsql/data/
+- name: PostgreSQL | Set PostgreSQL paths | RedHat
+  set_fact:
+    _pg_data_dir: "/var/lib/pgsql/data"
+    _pg_conf_dir: "/var/lib/pgsql/data"
+  when: ansible_facts['os_family'] == "RedHat"
+
+# ============ Generate Server Certificates ============
+# Now that postgres user exists, generate server certificates
+- name: PostgreSQL | Create TLS directory
+  file:
+    path: /etc/postgresql/tls
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0750"
+
+- name: PostgreSQL | Generate server private key
+  command: openssl genrsa -out /etc/postgresql/tls/server.key 2048
+  args:
+    creates: /etc/postgresql/tls/server.key
+
+- name: PostgreSQL | Create server certificate config
+  copy:
+    content: |
+      [req]
+      distinguished_name = req_distinguished_name
+      req_extensions = v3_req
+      prompt = no
+
+      [req_distinguished_name]
+      CN = localhost
+
+      [v3_req]
+      keyUsage = keyEncipherment, dataEncipherment
+      extendedKeyUsage = serverAuth
+      subjectAltName = @alt_names
+
+      [alt_names]
+      DNS.1 = localhost
+      IP.1 = 127.0.0.1
+    dest: /etc/postgresql/tls/server.cnf
+    mode: "0644"
+
+- name: PostgreSQL | Generate server CSR
+  command: >
+    openssl req -new
+    -key /etc/postgresql/tls/server.key
+    -out /etc/postgresql/tls/server.csr
+    -config /etc/postgresql/tls/server.cnf
+  args:
+    creates: /etc/postgresql/tls/server.csr
+
+- name: PostgreSQL | Sign server certificate with CA
+  command: >
+    openssl x509 -req
+    -in /etc/postgresql/tls/server.csr
+    -CA /etc/miarecweb/tls/ca.crt
+    -CAkey /etc/miarecweb/tls/ca.key
+    -CAcreateserial
+    -out /etc/postgresql/tls/server.crt
+    -days 365 -sha256
+    -extensions v3_req
+    -extfile /etc/postgresql/tls/server.cnf
+  args:
+    creates: /etc/postgresql/tls/server.crt
+
+- name: PostgreSQL | Copy CA certificate
+  copy:
+    src: /etc/miarecweb/tls/ca.crt
+    dest: /etc/postgresql/tls/ca.crt
+    mode: "0644"
+    remote_src: true
+
+- name: PostgreSQL | Set server key permissions
+  file:
+    path: /etc/postgresql/tls/server.key
+    mode: "0600"
+    owner: postgres
+    group: postgres
+
+- name: PostgreSQL | Set server certificate permissions
+  file:
+    path: /etc/postgresql/tls/server.crt
+    mode: "0644"
+    owner: postgres
+    group: postgres
+
+- name: PostgreSQL | Set CA certificate permissions
+  file:
+    path: /etc/postgresql/tls/ca.crt
+    mode: "0644"
+    owner: postgres
+    group: postgres
+
+# ============ Configure PostgreSQL for TLS ============
+- name: PostgreSQL | Enable SSL in postgresql.conf
+  lineinfile:
+    path: "{{ _pg_conf_dir }}/postgresql.conf"
+    regexp: "^#?ssl\\s*="
+    line: "ssl = on"
+
+- name: PostgreSQL | Configure SSL certificate file
+  lineinfile:
+    path: "{{ _pg_conf_dir }}/postgresql.conf"
+    regexp: "^#?ssl_cert_file\\s*="
+    line: "ssl_cert_file = '/etc/postgresql/tls/server.crt'"
+
+- name: PostgreSQL | Configure SSL key file
+  lineinfile:
+    path: "{{ _pg_conf_dir }}/postgresql.conf"
+    regexp: "^#?ssl_key_file\\s*="
+    line: "ssl_key_file = '/etc/postgresql/tls/server.key'"
+
+- name: PostgreSQL | Configure SSL CA file
+  lineinfile:
+    path: "{{ _pg_conf_dir }}/postgresql.conf"
+    regexp: "^#?ssl_ca_file\\s*="
+    line: "ssl_ca_file = '/etc/postgresql/tls/ca.crt'"
+
+# ============ Configure pg_hba.conf for TLS ============
+# Require TLS with client certificate verification
+- name: PostgreSQL | Configure pg_hba.conf with hostssl
+  copy:
+    content: |
+      # PostgreSQL Client Authentication Configuration File
+      # TYPE  DATABASE        USER            ADDRESS                 METHOD
+      local   all             all                                     peer
+      # Require SSL with client certificate verification for IPv4 and IPv6
+      hostssl miarecdb        miarec          127.0.0.1/32            md5 clientcert=verify-ca
+      hostssl miarecdb        miarec          ::1/128                 md5 clientcert=verify-ca
+      # Reject all non-SSL connections
+      hostnossl all           all             0.0.0.0/0               reject
+      hostnossl all           all             ::/0                    reject
+    dest: "{{ _pg_conf_dir }}/pg_hba.conf"
+    mode: "0640"
+    owner: postgres
+    group: postgres
+
+# ============ Start PostgreSQL ============
+- name: PostgreSQL | Start PostgreSQL service
+  service:
+    name: postgresql
+    state: restarted
+
+# ============ Create Database and User ============
+- name: PostgreSQL | Configure PostgreSQL
+  vars:
+    ansible_shell_allow_world_readable_temp: true
+  block:
+
+    - name: PostgreSQL | Check if user exists
+      command: psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='miarec'"
+      become: true
+      become_user: "postgres"
+      register: _pg_user_exists
+      changed_when: false
+
+    - name: PostgreSQL | Create user
+      command: psql -c "CREATE USER miarec WITH PASSWORD 'password';"
+      become: true
+      become_user: "postgres"
+      when: _pg_user_exists.stdout != "1"
+      changed_when: true
+
+    - name: PostgreSQL | Check if database exists
+      command: psql -tAc "SELECT 1 FROM pg_database WHERE datname='miarecdb'"
+      become: true
+      become_user: "postgres"
+      register: _pg_db_exists
+      changed_when: false
+
+    - name: PostgreSQL | Create Database
+      command: psql -c "CREATE DATABASE miarecdb OWNER miarec;"
+      become: true
+      become_user: "postgres"
+      when: _pg_db_exists.stdout != "1"
+      changed_when: true
+
+    - name: PostgreSQL | Create Extensions
+      command: "psql -d miarecdb -c 'CREATE EXTENSION IF NOT EXISTS \"{{ item }}\";'"
+      become: true
+      become_user: "postgres"
+      register: _pg_ext_result
+      changed_when: "'already exists' not in _pg_ext_result.stderr"
+      with_items:
+        - hstore
+        - uuid-ossp
+        - pg_stat_statements
+
+# ============ Verify TLS Configuration ============
+- name: PostgreSQL | Verify TLS connection with client certificate succeeds
+  command: >
+    psql
+    "host=127.0.0.1 port=5432 dbname=miarecdb user=miarec password=password
+    sslmode=verify-ca
+    sslrootcert=/etc/miarecweb/tls/ca.crt
+    sslcert=/etc/miarecweb/tls/client.crt
+    sslkey=/etc/miarecweb/tls/client.key"
+    -c "SELECT 1;"
+  register: _pg_tls_test
+  changed_when: false
+
+- name: PostgreSQL | Verify TLS connection succeeded
+  assert:
+    that:
+      - _pg_tls_test.rc == 0
+    fail_msg: "PostgreSQL TLS connection with client certificate failed"
+    success_msg: "PostgreSQL TLS connection with client certificate succeeded"
+
+- name: PostgreSQL | Verify non-TLS connection is rejected
+  command: >
+    psql
+    "host=127.0.0.1 port=5432 dbname=miarecdb user=miarec password=password
+    sslmode=disable"
+    -c "SELECT 1;"
+  register: _pg_no_tls_test
+  failed_when: false
+  changed_when: false
+
+- name: PostgreSQL | Verify non-TLS connection was rejected
+  assert:
+    that:
+      - _pg_no_tls_test.rc != 0
+    fail_msg: "PostgreSQL non-TLS connection should have been rejected but succeeded"
+    success_msg: "PostgreSQL non-TLS connection was correctly rejected"

--- a/molecule/tls/tasks/python.yml
+++ b/molecule/tls/tasks/python.yml
@@ -1,0 +1,51 @@
+---
+# Install Python from system packages
+# Uses python_version variable (e.g., "3.12") passed from prepare.yml
+
+# Parse python_version to get major.minor (e.g., "3.12" from "3.12.1")
+- name: Python | Parse version
+  set_fact:
+    _python_major_minor: "{{ '.'.join(python_version.split('.')[:2]) }}"
+
+# Define OS-specific Python packages
+- name: Python | Define packages | RedHat
+  set_fact:
+    python3_packages:
+      - "python{{ _python_major_minor }}"
+      - "python{{ _python_major_minor }}-devel"
+      - "python{{ _python_major_minor }}-pip"
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: Python | Define packages | Debian
+  set_fact:
+    python3_packages:
+      - python3
+      - python3-dev
+      - python3-venv
+  when: ansible_facts['os_family'] == "Debian"
+
+# Install EPEL for RedHat-based systems (except RHEL Enterprise itself)
+- name: Python | Install EPEL repository | RedHat
+  yum:
+    name: epel-release
+    state: present
+  when:
+    - ansible_facts['os_family'] == "RedHat"
+    - ansible_facts['distribution'] != "RedHat"
+
+# Enable Python module stream for RHEL 9+ (AppStream provides python3.12)
+- name: Python | Enable Python {{ _python_major_minor }} module | RHEL 9+
+  command: "dnf module enable python{{ _python_major_minor }} -y"
+  when:
+    - ansible_facts['distribution'] == "RedHat"
+    - ansible_facts['distribution_major_version'] | int >= 9
+  register: _python_module_enable
+  changed_when: "'Nothing to do' not in _python_module_enable.stdout"
+  failed_when: false
+
+# Install Python packages
+- name: Python | Install Python3 packages
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ python3_packages }}"

--- a/molecule/tls/tasks/redis_tls.yml
+++ b/molecule/tls/tasks/redis_tls.yml
@@ -1,0 +1,215 @@
+---
+# Install and Configure Redis with TLS from system packages
+# Server certificates are generated here after redis user exists
+
+# Install EPEL for CentOS (required for redis package)
+- name: Redis | Install EPEL | CentOS
+  package:
+    name: epel-release
+    state: present
+  when: ansible_facts['distribution'] == "CentOS"
+
+# Install Redis package
+- name: Redis | Install Redis package
+  package:
+    name: redis
+    state: present
+    update_cache: true
+
+# Define service name based on OS family
+- name: Redis | Define service name
+  set_fact:
+    redis_service_name: "{{ 'redis-server' if ansible_facts['os_family'] == 'Debian' else 'redis' }}"
+
+# ============ Generate Server Certificates ============
+# Now that redis user exists, generate server certificates
+- name: Redis | Create TLS directory
+  file:
+    path: /etc/redis/tls
+    state: directory
+    owner: redis
+    group: redis
+    mode: "0750"
+
+- name: Redis | Generate server private key
+  command: openssl genrsa -out /etc/redis/tls/server.key 2048
+  args:
+    creates: /etc/redis/tls/server.key
+
+- name: Redis | Create server certificate config
+  copy:
+    content: |
+      [req]
+      distinguished_name = req_distinguished_name
+      req_extensions = v3_req
+      prompt = no
+
+      [req_distinguished_name]
+      CN = localhost
+
+      [v3_req]
+      keyUsage = keyEncipherment, dataEncipherment
+      extendedKeyUsage = serverAuth
+      subjectAltName = @alt_names
+
+      [alt_names]
+      DNS.1 = localhost
+      IP.1 = 127.0.0.1
+    dest: /etc/redis/tls/server.cnf
+    mode: "0644"
+
+- name: Redis | Generate server CSR
+  command: >
+    openssl req -new
+    -key /etc/redis/tls/server.key
+    -out /etc/redis/tls/server.csr
+    -config /etc/redis/tls/server.cnf
+  args:
+    creates: /etc/redis/tls/server.csr
+
+- name: Redis | Sign server certificate with CA
+  command: >
+    openssl x509 -req
+    -in /etc/redis/tls/server.csr
+    -CA /etc/miarecweb/tls/ca.crt
+    -CAkey /etc/miarecweb/tls/ca.key
+    -CAcreateserial
+    -out /etc/redis/tls/server.crt
+    -days 365 -sha256
+    -extensions v3_req
+    -extfile /etc/redis/tls/server.cnf
+  args:
+    creates: /etc/redis/tls/server.crt
+
+- name: Redis | Copy CA certificate
+  copy:
+    src: /etc/miarecweb/tls/ca.crt
+    dest: /etc/redis/tls/ca.crt
+    mode: "0644"
+    remote_src: true
+
+- name: Redis | Set server key permissions
+  file:
+    path: /etc/redis/tls/server.key
+    mode: "0600"
+    owner: redis
+    group: redis
+
+- name: Redis | Set server certificate permissions
+  file:
+    path: /etc/redis/tls/server.crt
+    mode: "0644"
+    owner: redis
+    group: redis
+
+- name: Redis | Set CA certificate permissions
+  file:
+    path: /etc/redis/tls/ca.crt
+    mode: "0644"
+    owner: redis
+    group: redis
+
+# Start Redis temporarily to detect config file location
+- name: Redis | Start Redis service temporarily
+  systemd:
+    name: "{{ redis_service_name }}"
+    state: started
+    enabled: true
+
+# Detect Redis config path using redis-cli INFO
+- name: Redis | Get config file location from redis-cli INFO
+  shell: "redis-cli INFO | grep config_file | cut -d: -f2 | tr -d '\\r'"
+  register: _redis_info_config
+  changed_when: false
+
+- name: Redis | Set config path from redis-cli INFO
+  set_fact:
+    redis_conf_path: "{{ _redis_info_config.stdout | trim }}"
+
+- name: Redis | Fail if config file not detected
+  fail:
+    msg: "Could not detect Redis config file from redis-cli INFO"
+  when: redis_conf_path | length == 0
+
+# Configure Redis for TLS
+- name: Redis | Configure TLS port
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-port\\s+"
+    line: "tls-port 6379"
+
+- name: Redis | Disable non-TLS port
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^port\\s+"
+    line: "port 0"
+
+- name: Redis | Configure TLS certificate file
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-cert-file\\s+"
+    line: "tls-cert-file /etc/redis/tls/server.crt"
+
+- name: Redis | Configure TLS key file
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-key-file\\s+"
+    line: "tls-key-file /etc/redis/tls/server.key"
+
+- name: Redis | Configure TLS CA certificate
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-ca-cert-file\\s+"
+    line: "tls-ca-cert-file /etc/redis/tls/ca.crt"
+
+- name: Redis | Configure TLS auth clients (require client certificates)
+  lineinfile:
+    path: "{{ redis_conf_path }}"
+    regexp: "^#?\\s*tls-auth-clients\\s+"
+    line: "tls-auth-clients yes"
+
+# Start and enable Redis service
+- name: Redis | Restart Redis service with TLS
+  systemd:
+    name: "{{ redis_service_name }}"
+    state: restarted
+    enabled: true
+
+# ============ Verify TLS Configuration ============
+- name: Redis | Verify TLS connection with client certificate succeeds
+  command: >
+    redis-cli
+    --tls
+    --cacert /etc/miarecweb/tls/ca.crt
+    --cert /etc/miarecweb/tls/client.crt
+    --key /etc/miarecweb/tls/client.key
+    -h 127.0.0.1
+    -p 6379
+    PING
+  register: _redis_tls_test
+  changed_when: false
+
+- name: Redis | Verify TLS connection succeeded
+  assert:
+    that:
+      - _redis_tls_test.rc == 0
+      - "'PONG' in _redis_tls_test.stdout"
+    fail_msg: "Redis TLS connection with client certificate failed"
+    success_msg: "Redis TLS connection with client certificate succeeded"
+
+- name: Redis | Verify non-TLS connection is rejected
+  command: >
+    redis-cli
+    -h 127.0.0.1
+    -p 6379
+    PING
+  register: _redis_no_tls_test
+  failed_when: false
+  changed_when: false
+
+- name: Redis | Verify non-TLS connection was rejected
+  assert:
+    that:
+      - _redis_no_tls_test.rc != 0 or 'PONG' not in _redis_no_tls_test.stdout
+    fail_msg: "Redis non-TLS connection should have been rejected but succeeded"
+    success_msg: "Redis non-TLS connection was correctly rejected"

--- a/molecule/tls/tasks/redis_tls.yml
+++ b/molecule/tls/tasks/redis_tls.yml
@@ -118,7 +118,9 @@
 
 # Detect Redis config path using redis-cli INFO
 - name: Redis | Get config file location from redis-cli INFO
-  shell: "redis-cli INFO | grep config_file | cut -d: -f2 | tr -d '\\r'"
+  shell: "set -o pipefail && redis-cli INFO | grep config_file | cut -d: -f2 | tr -d '\\r'"
+  args:
+    executable: /bin/bash
   register: _redis_info_config
   changed_when: false
 

--- a/molecule/tls/tests/test_tls.py
+++ b/molecule/tls/tests/test_tls.py
@@ -1,0 +1,168 @@
+import json
+import os
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+miarecweb_version = os.environ.get('MIARECWEB_VERSION')
+
+
+def test_tls_certificates_exist(host):
+    """Verify TLS certificates were generated."""
+    cert_files = [
+        # CA and client certs in /etc/miarecweb/tls/
+        "/etc/miarecweb/tls/ca.crt",
+        "/etc/miarecweb/tls/client.crt",
+        "/etc/miarecweb/tls/client.key",
+        # PostgreSQL server certs in /etc/postgresql/tls/
+        "/etc/postgresql/tls/server.crt",
+        "/etc/postgresql/tls/server.key",
+        "/etc/postgresql/tls/ca.crt",
+        # Redis server certs in /etc/redis/tls/
+        "/etc/redis/tls/server.crt",
+        "/etc/redis/tls/server.key",
+        "/etc/redis/tls/ca.crt",
+    ]
+    for cert_file in cert_files:
+        f = host.file(cert_file)
+        assert f.exists, f"Certificate file not found: {cert_file}"
+        assert f.is_file, f"Not a file: {cert_file}"
+
+
+def test_production_ini_db_ssl_params(host):
+    """Verify DATABASE_SSL_PARAMS is configured in production.ini."""
+    ini_file = host.file(
+        f"/opt/miarecweb/releases/{miarecweb_version}/production.ini"
+    )
+    assert ini_file.exists, "production.ini not found"
+
+    content = ini_file.content_string
+    assert "DATABASE_SSL_PARAMS" in content, "DATABASE_SSL_PARAMS not found in production.ini"
+    assert "sslmode=verify-ca" in content, "sslmode not configured correctly"
+    assert "sslrootcert=/etc/miarecweb/tls/ca.crt" in content, "sslrootcert not configured"
+    assert "sslcert=/etc/miarecweb/tls/client.crt" in content, "sslcert not configured"
+    assert "sslkey=/etc/miarecweb/tls/client.key" in content, "sslkey not configured"
+
+
+def test_production_ini_redis_ssl_params(host):
+    """Verify Redis TLS settings are configured in production.ini."""
+    ini_file = host.file(
+        f"/opt/miarecweb/releases/{miarecweb_version}/production.ini"
+    )
+    assert ini_file.exists, "production.ini not found"
+
+    content = ini_file.content_string
+    assert "REDIS_SCHEMA" in content, "REDIS_SCHEMA not found in production.ini"
+    assert "rediss" in content, "Redis TLS schema (rediss) not configured"
+    assert "REDIS_SSL_PARAMS" in content, "REDIS_SSL_PARAMS not found in production.ini"
+    assert "ssl_ca_certs=/etc/miarecweb/tls/ca.crt" in content, "ssl_ca_certs not configured"
+    assert "ssl_certfile=/etc/miarecweb/tls/client.crt" in content, "ssl_certfile not configured"
+    assert "ssl_keyfile=/etc/miarecweb/tls/client.key" in content, "ssl_keyfile not configured"
+
+
+def test_postgresql_ssl_enabled(host):
+    """Verify PostgreSQL has SSL enabled."""
+    result = host.run(
+        "sudo -u postgres psql -tAc \"SHOW ssl;\""
+    )
+    assert result.rc == 0, f"Failed to query PostgreSQL: {result.stderr}"
+    assert "on" in result.stdout, "PostgreSQL SSL is not enabled"
+
+
+def test_redis_tls_listening(host):
+    """Verify Redis is listening on TLS port."""
+    socket = host.socket("tcp://127.0.0.1:6379")
+    assert socket.is_listening, "Redis is not listening on TLS port 6379"
+
+
+def test_directories(host):
+    """Verify required directories exist."""
+    dirs = [
+        f"/opt/miarecweb/releases/{miarecweb_version}",
+        "/var/log/miarecweb",
+        "/var/log/miarecweb/celery"
+    ]
+    for dir_path in dirs:
+        d = host.file(dir_path)
+        assert d.is_directory, f"Directory not found: {dir_path}"
+        assert d.exists, f"Directory does not exist: {dir_path}"
+
+
+def test_files(host):
+    """Verify required files exist."""
+    files = [
+        f"/opt/miarecweb/releases/{miarecweb_version}/production.ini",
+        "/etc/systemd/system/celerybeat.service",
+        "/etc/systemd/system/celeryd.service",
+    ]
+    for file_path in files:
+        f = host.file(file_path)
+        assert f.exists, f"File not found: {file_path}"
+        assert f.is_file, f"Not a file: {file_path}"
+
+
+def test_services(host):
+    """Verify services are enabled and running."""
+    if host.system_info.distribution == "ubuntu":
+        services = ["apache2", "celeryd", "celerybeat"]
+    else:
+        services = ["httpd", "celeryd", "celerybeat"]
+
+    for service in services:
+        s = host.service(service)
+        assert s.is_enabled, f"Service {service} is not enabled"
+        assert s.is_running, f"Service {service} is not running"
+
+
+def test_health_endpoint(host):
+    """Verify /health endpoint returns healthy status for dependencies."""
+    result = host.run("curl -sS -w '\\n%{http_code}' http://localhost/health")
+    assert result.rc == 0, f"Health endpoint curl failed (rc={result.rc}): {result.stderr}"
+
+    output_lines = result.stdout.splitlines()
+    assert output_lines, "Health endpoint returned no output"
+
+    status_line = output_lines[-1]
+    body = "\n".join(output_lines[:-1])
+
+    try:
+        http_status = int(status_line)
+    except ValueError as exc:
+        raise AssertionError(
+            f"Could not parse HTTP status from health response: {status_line}\n"
+            f"Full response:\n{result.stdout}\nStderr:\n{result.stderr}"
+        ) from exc
+
+    if http_status != 200:
+        raise AssertionError(
+            f"Health endpoint returned HTTP {http_status}\n"
+            f"Body:\n{body or '<empty>'}\nStderr:\n{result.stderr}"
+        )
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"Health endpoint response is not valid JSON: {exc}\nResponse: {body}"
+        )
+
+    assert payload.get("status") == "ok", f"Unexpected overall status: {payload}"
+    assert payload.get("postgresql") == "ok", f"Unexpected PostgreSQL status: {payload}"
+    assert payload.get("redis") == "ok", f"Unexpected Redis status: {payload}"
+
+
+def test_alembic_with_tls(host):
+    """Verify alembic can connect to PostgreSQL with TLS (via environment variables)."""
+    # This works because upgrade_db.yml passes PGSSLMODE/PGSSLCERT/PGSSLKEY
+    # as environment variables to alembic commands
+    result = host.run(
+        "PGSSLMODE=verify-ca "
+        "PGSSLCERT=/etc/miarecweb/tls/client.crt "
+        "PGSSLKEY=/etc/miarecweb/tls/client.key "
+        "PGSSLROOTCERT=/etc/miarecweb/tls/ca.crt "
+        "/opt/miarecweb/current/pyenv/bin/alembic -c /opt/miarecweb/current/production.ini current"
+    )
+    assert result.rc == 0, f"Alembic failed to connect with TLS: {result.stderr}"
+    assert "(head)" in result.stdout or "head" in result.stdout.lower(), \
+        f"Database not at head revision: {result.stdout}"

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -20,6 +20,7 @@
     - libffi-dev
     - unixodbc-dev
     - postgresql-client
+    - libsndfile1
   when: ansible_facts['os_family'] == "Debian"
 
 # packaging module is required for Ansible's pip module when Python is installed from packages
@@ -84,6 +85,7 @@
     - libxslt-devel
     - postgresql-devel
     - unixODBC-devel
+    - libsndfile
   when: ansible_facts['os_family'] == "RedHat"
 
 # this is required for mod_wsgi install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,41 @@
   when: miarec_bin_group != 'root'
 
 # --------------------------------------------------
+# Configure TLS certificate permissions
+# When TLS is enabled with client certificates, ensure the
+# certificate files are readable by the miarec_bin_group
+# --------------------------------------------------
+- name: Set group ownership on TLS certificate files
+  file:
+    path: "{{ item }}"
+    group: "{{ miarec_bin_group }}"
+    mode: "u=rw,g=r,o="
+  loop: "{{ _tls_key_files | select | list }}"
+  vars:
+    _tls_key_files:
+      - "{{ miarecweb_db_tls_key_file if (miarecweb_db_tls | bool and miarecweb_db_tls_key_file | length > 0) else '' }}"
+      - "{{ miarecweb_redis_tls_key_file if (miarecweb_redis_tls | bool and miarecweb_redis_tls_key_file | length > 0) else '' }}"
+  when:
+    - miarec_bin_group != 'root'
+    - _tls_key_files | select | list | length > 0
+  become: true
+
+- name: Set group ownership on TLS certificate directory
+  file:
+    path: "{{ item | dirname }}"
+    group: "{{ miarec_bin_group }}"
+    mode: "u=rwx,g=rx,o="
+  loop: "{{ _tls_key_files | select | list }}"
+  vars:
+    _tls_key_files:
+      - "{{ miarecweb_db_tls_key_file if (miarecweb_db_tls | bool and miarecweb_db_tls_key_file | length > 0) else '' }}"
+      - "{{ miarecweb_redis_tls_key_file if (miarecweb_redis_tls | bool and miarecweb_redis_tls_key_file | length > 0) else '' }}"
+  when:
+    - miarec_bin_group != 'root'
+    - _tls_key_files | select | list | length > 0
+  become: true
+
+# --------------------------------------------------
 # Initialize the installation/upgrade process
 # --------------------------------------------------
 - name: Initialize the deploy root and gather facts

--- a/tasks/miarecweb.yml
+++ b/tasks/miarecweb.yml
@@ -182,6 +182,70 @@
     - reload celeryd
     - reload celerybeat
 
+# Configure PostgreSQL TLS settings
+- name: Configure DATABASE_SSL_PARAMS in production.ini
+  lineinfile:
+    dest: "{{ ansible_facts['deploy_helper']['new_release_path'] }}/production.ini"
+    regexp: '^DATABASE_SSL_PARAMS\s*='
+    line: "DATABASE_SSL_PARAMS = {{ _db_ssl_params }}"
+  vars:
+    _db_ssl_params: >-
+      {%- set params = [] -%}
+      {%- if miarecweb_db_tls | bool -%}
+        {%- set params = params + ['sslmode=' + miarecweb_db_tls_sslmode] -%}
+        {%- if miarecweb_db_tls_ca_file -%}
+          {%- set params = params + ['sslrootcert=' + miarecweb_db_tls_ca_file] -%}
+        {%- endif -%}
+        {%- if miarecweb_db_tls_cert_file -%}
+          {%- set params = params + ['sslcert=' + miarecweb_db_tls_cert_file] -%}
+        {%- endif -%}
+        {%- if miarecweb_db_tls_key_file -%}
+          {%- set params = params + ['sslkey=' + miarecweb_db_tls_key_file] -%}
+        {%- endif -%}
+      {%- endif -%}
+      {{ params | join('&') }}
+  notify:
+    - reload apache
+    - reload celeryd
+    - reload celerybeat
+
+# Configure Redis TLS settings
+- name: Configure REDIS_SCHEMA in production.ini
+  lineinfile:
+    dest: "{{ ansible_facts['deploy_helper']['new_release_path'] }}/production.ini"
+    regexp: '^REDIS_SCHEMA\s*='
+    line: "REDIS_SCHEMA = {{ 'rediss' if miarecweb_redis_tls | bool else 'redis' }}"
+  notify:
+    - reload apache
+    - reload celeryd
+    - reload celerybeat
+
+- name: Configure REDIS_SSL_PARAMS in production.ini
+  lineinfile:
+    dest: "{{ ansible_facts['deploy_helper']['new_release_path'] }}/production.ini"
+    regexp: '^REDIS_SSL_PARAMS\s*='
+    line: "REDIS_SSL_PARAMS = {{ _redis_ssl_params }}"
+  vars:
+    _redis_ssl_params: >-
+      {%- set params = [] -%}
+      {%- if miarecweb_redis_tls | bool -%}
+        {%- set params = params + ['ssl_cert_reqs=' + miarecweb_redis_tls_cert_reqs] -%}
+        {%- set params = params + ['ssl_check_hostname=' + (miarecweb_redis_tls_check_hostname | string)] -%}
+        {%- if miarecweb_redis_tls_ca_file -%}
+          {%- set params = params + ['ssl_ca_certs=' + miarecweb_redis_tls_ca_file] -%}
+        {%- endif -%}
+        {%- if miarecweb_redis_tls_cert_file -%}
+          {%- set params = params + ['ssl_certfile=' + miarecweb_redis_tls_cert_file] -%}
+        {%- endif -%}
+        {%- if miarecweb_redis_tls_key_file -%}
+          {%- set params = params + ['ssl_keyfile=' + miarecweb_redis_tls_key_file] -%}
+        {%- endif -%}
+      {%- endif -%}
+      {{ params | join('&') }}
+  notify:
+    - reload apache
+    - reload celeryd
+    - reload celerybeat
 
 - name: Configure secrets in production.ini file
   lineinfile:

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -8,9 +8,14 @@
     - "../vars/{{ ansible_facts['os_family'] }}.yml"
 
 
+- name: Check for miarecweb_version variable.
+  fail:
+    msg: Parameter 'miarecweb_version' must be provided. Specify the version to install (e.g., '2024.1.0.0').
+  when: not miarecweb_version
+
 - name: Check for miarecweb_secret variable.
   fail:
-    msg: Parameters 'miarecweb_secret' must be provided.
+    msg: Parameter 'miarecweb_secret' must be provided.
   when: not miarecweb_secret
 
 - name: Check for illeagal character in secrets.
@@ -18,6 +23,128 @@
     msg: Illeagal character, miarecweb_secret or miarecweb_db_password cannot contain '%'.
   when:
     - miarecweb_secret is search("%") or miarecweb_db_password is search("%")
+
+# ---------------------------------------------
+# Validate TLS certificate files
+# ---------------------------------------------
+- name: Validate PostgreSQL TLS CA file exists
+  stat:
+    path: "{{ miarecweb_db_tls_ca_file }}"
+  register: _db_tls_ca_stat
+  when:
+    - miarecweb_db_tls | bool
+    - miarecweb_db_tls_ca_file | length > 0
+
+- name: Fail if PostgreSQL TLS CA file not found
+  fail:
+    msg: "PostgreSQL TLS CA file not found: {{ miarecweb_db_tls_ca_file }}"
+  when:
+    - miarecweb_db_tls | bool
+    - miarecweb_db_tls_ca_file | length > 0
+    - _db_tls_ca_stat.stat is defined
+    - not _db_tls_ca_stat.stat.exists
+
+- name: Validate PostgreSQL TLS client certificate file exists
+  stat:
+    path: "{{ miarecweb_db_tls_cert_file }}"
+  register: _db_tls_cert_stat
+  when:
+    - miarecweb_db_tls | bool
+    - miarecweb_db_tls_cert_file | length > 0
+
+- name: Fail if PostgreSQL TLS client certificate file not found
+  fail:
+    msg: "PostgreSQL TLS client certificate file not found: {{ miarecweb_db_tls_cert_file }}"
+  when:
+    - miarecweb_db_tls | bool
+    - miarecweb_db_tls_cert_file | length > 0
+    - _db_tls_cert_stat.stat is defined
+    - not _db_tls_cert_stat.stat.exists
+
+- name: Validate PostgreSQL TLS client key file exists
+  stat:
+    path: "{{ miarecweb_db_tls_key_file }}"
+  register: _db_tls_key_stat
+  when:
+    - miarecweb_db_tls | bool
+    - miarecweb_db_tls_key_file | length > 0
+
+- name: Fail if PostgreSQL TLS client key file not found
+  fail:
+    msg: "PostgreSQL TLS client key file not found: {{ miarecweb_db_tls_key_file }}"
+  when:
+    - miarecweb_db_tls | bool
+    - miarecweb_db_tls_key_file | length > 0
+    - _db_tls_key_stat.stat is defined
+    - not _db_tls_key_stat.stat.exists
+
+- name: Validate Redis TLS CA file exists
+  stat:
+    path: "{{ miarecweb_redis_tls_ca_file }}"
+  register: _redis_tls_ca_stat
+  when:
+    - miarecweb_redis_tls | bool
+    - miarecweb_redis_tls_ca_file | length > 0
+
+- name: Fail if Redis TLS CA file not found
+  fail:
+    msg: "Redis TLS CA file not found: {{ miarecweb_redis_tls_ca_file }}"
+  when:
+    - miarecweb_redis_tls | bool
+    - miarecweb_redis_tls_ca_file | length > 0
+    - _redis_tls_ca_stat.stat is defined
+    - not _redis_tls_ca_stat.stat.exists
+
+- name: Validate Redis TLS client certificate file exists
+  stat:
+    path: "{{ miarecweb_redis_tls_cert_file }}"
+  register: _redis_tls_cert_stat
+  when:
+    - miarecweb_redis_tls | bool
+    - miarecweb_redis_tls_cert_file | length > 0
+
+- name: Fail if Redis TLS client certificate file not found
+  fail:
+    msg: "Redis TLS client certificate file not found: {{ miarecweb_redis_tls_cert_file }}"
+  when:
+    - miarecweb_redis_tls | bool
+    - miarecweb_redis_tls_cert_file | length > 0
+    - _redis_tls_cert_stat.stat is defined
+    - not _redis_tls_cert_stat.stat.exists
+
+- name: Validate Redis TLS client key file exists
+  stat:
+    path: "{{ miarecweb_redis_tls_key_file }}"
+  register: _redis_tls_key_stat
+  when:
+    - miarecweb_redis_tls | bool
+    - miarecweb_redis_tls_key_file | length > 0
+
+- name: Fail if Redis TLS client key file not found
+  fail:
+    msg: "Redis TLS client key file not found: {{ miarecweb_redis_tls_key_file }}"
+  when:
+    - miarecweb_redis_tls | bool
+    - miarecweb_redis_tls_key_file | length > 0
+    - _redis_tls_key_stat.stat is defined
+    - not _redis_tls_key_stat.stat.exists
+
+# ---------------------------------------------
+# Validate TLS configuration requirements
+# When TLS is enabled with client certificates, the celery user
+# and apache need to read the private key files. Running as root
+# is not supported - a dedicated user/group must be configured.
+# ---------------------------------------------
+- name: Check TLS configuration requires non-root celery user
+  fail:
+    msg: >-
+      TLS with client certificates requires a non-root celery user.
+      Set 'miarecweb_celery_user' to a dedicated user (e.g., 'celery')
+      and 'miarec_bin_group' to a shared group that can read the certificate files.
+  when:
+    - (miarecweb_db_tls | bool and miarecweb_db_tls_key_file | length > 0) or
+      (miarecweb_redis_tls | bool and miarecweb_redis_tls_key_file | length > 0)
+    - miarecweb_celery_user == 'root'
 
 # ---------------------------------------------
 # Detect/verify python installation on this server

--- a/tasks/upgrade_db.yml
+++ b/tasks/upgrade_db.yml
@@ -1,6 +1,11 @@
 ---
 - name: Check if database layout is up-to-date
   command: "{{ ansible_facts['deploy_helper']['new_release_path'] }}/pyenv/bin/alembic -c {{ ansible_facts['deploy_helper']['new_release_path'] }}/production.ini current"
+  environment:
+    PGSSLMODE: "{{ miarecweb_db_tls_sslmode if miarecweb_db_tls | bool else 'disable' }}"
+    PGSSLROOTCERT: "{{ miarecweb_db_tls_ca_file if (miarecweb_db_tls | bool and miarecweb_db_tls_ca_file) else '' }}"
+    PGSSLCERT: "{{ miarecweb_db_tls_cert_file if (miarecweb_db_tls | bool and miarecweb_db_tls_cert_file) else '' }}"
+    PGSSLKEY: "{{ miarecweb_db_tls_key_file if (miarecweb_db_tls | bool and miarecweb_db_tls_key_file) else '' }}"
   register: _alembic_current_revision
   changed_when: false
   run_once: "{{ miarecweb_upgrade_db_once|default(True) }}"   # execute this task once during a playbook execution, even though the role is applied to many hosts
@@ -25,6 +30,11 @@
 
 - name: Upgrade database layout   # noqa: no-changed-when
   command: "{{ ansible_facts['deploy_helper']['new_release_path'] }}/pyenv/bin/alembic -c {{ ansible_facts['deploy_helper']['new_release_path'] }}/production.ini upgrade heads"
+  environment:
+    PGSSLMODE: "{{ miarecweb_db_tls_sslmode if miarecweb_db_tls | bool else 'disable' }}"
+    PGSSLROOTCERT: "{{ miarecweb_db_tls_ca_file if (miarecweb_db_tls | bool and miarecweb_db_tls_ca_file) else '' }}"
+    PGSSLCERT: "{{ miarecweb_db_tls_cert_file if (miarecweb_db_tls | bool and miarecweb_db_tls_cert_file) else '' }}"
+    PGSSLKEY: "{{ miarecweb_db_tls_key_file if (miarecweb_db_tls | bool and miarecweb_db_tls_key_file) else '' }}"
   register: _alembic_upgrade_head
   when: 'alembic_current_revision is defined and " (head)" not in alembic_current_revision'
   run_once: "{{ miarecweb_upgrade_db_once|default(True) }}"   # execute this task once during a playbook execution, even though the role is applied to many hosts
@@ -43,5 +53,9 @@
     PGDATABASE: "{{ miarecweb_db_name }}"
     PGHOST: "{{ miarecweb_db_host }}"
     PGPORT: "{{ miarecweb_db_port }}"
+    PGSSLMODE: "{{ miarecweb_db_tls_sslmode if miarecweb_db_tls | bool else 'disable' }}"
+    PGSSLROOTCERT: "{{ miarecweb_db_tls_ca_file if (miarecweb_db_tls | bool and miarecweb_db_tls_ca_file) else '' }}"
+    PGSSLCERT: "{{ miarecweb_db_tls_cert_file if (miarecweb_db_tls | bool and miarecweb_db_tls_cert_file) else '' }}"
+    PGSSLKEY: "{{ miarecweb_db_tls_key_file if (miarecweb_db_tls | bool and miarecweb_db_tls_key_file) else '' }}"
   when: 'alembic_current_revision is defined and " (head)" not in alembic_current_revision'
   run_once: "{{ miarecweb_upgrade_db_once|default(True) }}"   # execute this task once during a playbook execution, even though the role is applied to many hosts


### PR DESCRIPTION
## Summary

Add TLS/SSL connection support for PostgreSQL and Redis, enabling encrypted and optionally mutually-authenticated (mTLS) connections to database services.

---

## Purpose

This change enables secure database connections in environments that require TLS encryption for compliance or security requirements. It supports:
- Server certificate validation (verify-ca, verify-full)
- Client certificate authentication (mTLS)
- Flexible SSL mode configuration for PostgreSQL
- Redis TLS with configurable certificate requirements

---

## Testing

* [x] Added/updated tests
* [x] Ran `uv run ansible-lint` (1 minor warning in test infrastructure)
* Notes:
  - New `molecule/tls` scenario tests full mTLS configuration
  - Tests verify TLS certificates, production.ini configuration, health endpoints, and alembic connectivity
  - Tested on Ubuntu 24.04 and Rocky Linux 9

---

## Related Issues

N/A

---

## Changes

### New Variables (defaults/main.yml)

**PostgreSQL TLS:**
- `miarecweb_db_tls` - Enable TLS (default: false)
- `miarecweb_db_tls_sslmode` - SSL mode: disable, allow, prefer, require, verify-ca, verify-full (default: verify-ca)
- `miarecweb_db_tls_ca_file` - CA certificate path
- `miarecweb_db_tls_cert_file` - Client certificate path (for mTLS)
- `miarecweb_db_tls_key_file` - Client private key path (for mTLS)

**Redis TLS:**
- `miarecweb_redis_tls` - Enable TLS (default: false)
- `miarecweb_redis_tls_ca_file` - CA certificate path
- `miarecweb_redis_tls_cert_file` - Client certificate path (for mTLS)
- `miarecweb_redis_tls_key_file` - Client private key path (for mTLS)
- `miarecweb_redis_tls_cert_reqs` - Certificate requirement: required, optional, none (default: required)
- `miarecweb_redis_tls_check_hostname` - Verify server hostname (default: false)

### Role Changes

- **Preflight validation** - Validates TLS certificate files exist before deployment
- **Security enforcement** - Requires non-root celery user when using client certificates
- **Permission management** - Sets appropriate group ownership on TLS private keys
- **Configuration generation** - Writes DATABASE_SSL_PARAMS and REDIS_SSL_PARAMS to production.ini
- **Database migrations** - Passes TLS environment variables to alembic commands

### Test Infrastructure

- New `molecule/tls` scenario with full mTLS testing
- CA and client certificate generation
- PostgreSQL and Redis TLS server configuration
- Comprehensive test coverage for TLS connectivity

---

## Notes for Reviewers

1. **Breaking change consideration**: When TLS with client certificates is enabled, the role now requires `miarecweb_celery_user` to be set to a non-root user and `miarec_bin_group` to be configured. This ensures the celery worker can read the private key files.

2. **Certificate management**: This role provisions TLS parameters but does NOT manage certificate deployment. Certificates must be pre-deployed to the target system before running this role.

3. **Redis schema change**: When `miarecweb_redis_tls` is enabled, the Redis connection URL scheme changes from `redis://` to `rediss://`.

4. **ansible-lint warning**: One minor `risky-shell-pipe` warning in `molecule/tls/tasks/redis_tls.yml:120` - this is in test infrastructure only, not the main role.

---

## Docs

* [x] N/A (internal role, no external documentation required)
* [ ] Updated relevant documentation
