### PR TITLE
File Permission Updates 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,13 +130,13 @@
 
 - name: Check MiaRecWeb source directory
   stat:
-    path: "{{ ansible_facts['deploy_helper']['new_release_path'] }}/app/miarecweb"
+    path: "{{ ansible_facts['deploy_helper']['new_release_path'] }}/app"
   register: _miarecweb_source_dir
   become: true
 
 - name: Normalize permissions on MiaRecWeb sources
   file:
-    path: "{{ ansible_facts['deploy_helper']['new_release_path'] }}/app/miarecweb"
+    path: "{{ ansible_facts['deploy_helper']['new_release_path'] }}/app"
     state: directory
     recurse: true
     mode: u=rwX,g=rX,o=rX


### PR DESCRIPTION
# Pull Request Description Template

## 🔍 Summary

Extend the final permission normalization step to cover the entire release `app` directory so every package, migration, and asset shipped with MiaRec Web ends up with read-only group/other bits.

---

## 🎯 Purpose

The packaging layout now drops helper modules (for example, Celery bootstrap files) directly under `app/`, and restricting the `stat`/`file` tasks to `app/miarecweb` left those paths with whatever permissions the archive provided. By normalizing the whole release tree we keep Molecule idempotence clean and avoid future drifts as new top-level modules appear.

---

## 🧪 Testing

How did you verify it works?

* [ ] Added/updated tests
* [x] Ran `pytest`

Notes:
- `uv run molecule test` (default scenario)

---

## 📌 Related Issues

Closes #N/A

---

## 🚀 Changes

Brief list of main changes:

* Normalize permissions against `{{ deploy_helper.new_release_path }}/app` instead of limiting the check to the `miarecweb` package directory.

---

## ⚠️ Notes for Reviewers

If you have custom post-deploy hooks that place artifacts in `app/` after the role runs, confirm those still set their own permissions as needed; the role now assumes ownership of the entire directory.

---

## 📚 Docs

* [ ] Updated docs
